### PR TITLE
Clock Node

### DIFF
--- a/lib/audio-graph/index.ts
+++ b/lib/audio-graph/index.ts
@@ -1,5 +1,6 @@
 export * from "./src/context";
 export * from "./src/nodes/base";
+export * from "./src/nodes/clock";
 export * from "./src/nodes/dac";
 export * from "./src/nodes/factory";
 export * from "./src/nodes/gain";

--- a/lib/audio-graph/index.ts
+++ b/lib/audio-graph/index.ts
@@ -1,4 +1,5 @@
 export * from "./src/context";
+export * from "./src/events/coordinator";
 export * from "./src/nodes/base";
 export * from "./src/nodes/clock";
 export * from "./src/nodes/dac";

--- a/lib/audio-graph/src/context.ts
+++ b/lib/audio-graph/src/context.ts
@@ -1,8 +1,5 @@
-import {
-  AudioGraphConnection,
-  AudioGraphNode,
-  AudioGraphNodeParameters,
-} from "./nodes/base";
+import { ControlEventCoordinator } from "./events/coordinator";
+import { AudioGraphNode, AudioGraphNodeParameters } from "./nodes/base";
 import {
   AudioGraphCreateNodeParameters,
   createAudioGraphNode,
@@ -10,6 +7,7 @@ import {
 
 export interface WebAudio {
   audioContext?: AudioContext | undefined;
+  eventCoordinator?: ControlEventCoordinator | undefined;
   nodes: { [key: string]: AudioGraphNode };
   createNode: (params: AudioGraphCreateNodeParameters) => void;
   updateNode: (

--- a/lib/audio-graph/src/events/coordinator.ts
+++ b/lib/audio-graph/src/events/coordinator.ts
@@ -1,0 +1,64 @@
+export interface ControlEventEmitter {
+  id: string;
+}
+
+export interface ControlEvent {
+  name: string;
+  source: ControlEventEmitter;
+  data: { [key: string]: unknown };
+}
+
+export interface ControlEventReceiver {
+  id: string;
+  on: (event: ControlEvent) => void;
+}
+
+export interface ControlEventCoordinator {
+  handlers: { [key: string]: ControlEventReceiver[] };
+  subscribe: ({
+    eventName,
+    source,
+    target,
+  }: {
+    eventName: string;
+    source: ControlEventEmitter;
+    target: ControlEventReceiver;
+  }) => string;
+  unsubscribe: ({
+    eventId,
+    target,
+  }: {
+    eventId: string;
+    target: ControlEventReceiver;
+  }) => void;
+  emit: (event: ControlEvent) => void;
+}
+
+export const createControlEventCoordinator = (): ControlEventCoordinator => {
+  const coordinator: ControlEventCoordinator = {
+    handlers: {},
+    subscribe({ eventName, source, target }) {
+      const eventId = `${eventName}#${source.id}`;
+      if (!this.handlers[eventId]) {
+        this.handlers[eventId] = [];
+      }
+
+      this.handlers[eventId].push(target);
+
+      return eventId;
+    },
+    unsubscribe({ eventId, target }) {
+      const idx = this.handlers[eventId]?.findIndex((t) => t.id == target.id);
+      if (idx >= 0) {
+        this.handlers[eventId].splice(idx, 1);
+      }
+    },
+    emit(event) {
+      const { name, source } = event;
+      const eventId = `${name}#${source.id}`;
+      this.handlers[eventId]?.forEach((target) => target.on(event));
+    },
+  };
+
+  return coordinator;
+};

--- a/lib/audio-graph/src/nodes/base.ts
+++ b/lib/audio-graph/src/nodes/base.ts
@@ -1,10 +1,12 @@
+import { ClockGraphNodeParameters } from "./clock";
 import { DacGraphNodeParameters } from "./dac";
 import { GainGraphNodeParameters } from "./gain";
 import { OscillatorGraphNodeParameters } from "./oscillator";
 
-export type AudioGraphNodeType = "osc" | "gain" | "dac";
+export type AudioGraphNodeType = "clock" | "osc" | "gain" | "dac";
 
 export type AudioGraphNodeParameters =
+  | ClockGraphNodeParameters
   | DacGraphNodeParameters
   | GainGraphNodeParameters
   | OscillatorGraphNodeParameters;

--- a/lib/audio-graph/src/nodes/base.ts
+++ b/lib/audio-graph/src/nodes/base.ts
@@ -5,11 +5,19 @@ import { OscillatorGraphNodeParameters } from "./oscillator";
 
 export type AudioGraphNodeType = "clock" | "osc" | "gain" | "dac";
 
+export type AudioGraphConnectionRate = "audio" | "control" | "constant";
+
 export type AudioGraphNodeParameters =
   | ClockGraphNodeParameters
   | DacGraphNodeParameters
   | GainGraphNodeParameters
   | OscillatorGraphNodeParameters;
+
+export type AudioGraphSlot = {
+  key: string;
+  name: string;
+  rate: string;
+};
 
 export type AudioGraphConnection = {
   target: AudioGraphNode;
@@ -34,6 +42,12 @@ export interface AudioGraphNode {
 
   /** The default slot the nodes uses when working with connections. */
   defaultSlot: string;
+
+  /** All available input slots for the node with their update rate. */
+  inputs: { [key: string]: AudioGraphSlot };
+
+  /** All available output slots for the node with their update rate. */
+  outputs: { [key: string]: AudioGraphSlot };
 
   /** Establishes a connection with another node, if permitted by the target. */
   connect: (params: AudioGraphConnection) => void;

--- a/lib/audio-graph/src/nodes/clock.ts
+++ b/lib/audio-graph/src/nodes/clock.ts
@@ -68,7 +68,7 @@ export const createClock = (
     },
     destroy() {
       const osc = this.nodes.osc;
-
+      osc.onended = null;
       osc.stop();
       osc.disconnect();
     },
@@ -93,7 +93,7 @@ export const createClock = (
       oldOsc.stop();
 
       const newOsc = this.audioContext.createOscillator();
-      newOsc.frequency.value = this.nodes.osc.frequency.value;
+      newOsc.frequency.value = oldOsc.frequency.value;
       newOsc.type = "sawtooth";
 
       this.nodes.osc = newOsc;

--- a/lib/audio-graph/src/nodes/clock.ts
+++ b/lib/audio-graph/src/nodes/clock.ts
@@ -1,0 +1,106 @@
+import { AudioGraphNode, connectNodes, disconnectNodes } from "./base";
+import { AudioGraphFactoryParameters } from "./factory";
+
+export interface ClockGraphNodeParameters {
+  bpm: number;
+}
+
+export interface ClockGraphNode extends AudioGraphNode {
+  type: "clock";
+  defaultSlot: "trigger";
+  audioContext: AudioContext;
+  nodes: {
+    osc: OscillatorNode;
+  };
+  connections: {
+    trigger: string[];
+  };
+  start: () => void;
+  reset: () => void;
+}
+
+export const createClock = (
+  params: AudioGraphFactoryParameters,
+): ClockGraphNode => {
+  const { id, ctx } = params;
+
+  if (!ctx.audioContext) {
+    throw Error("AudioContext is required to create nodes.");
+  }
+
+  const { bpm = 60.0 } = params as ClockGraphNodeParameters;
+  const freq = bpm / 60.0;
+  const waveform = "sawtooth";
+
+  const osc = ctx.audioContext.createOscillator();
+  osc.frequency.value = freq;
+  osc.type = waveform;
+
+  const node: ClockGraphNode = {
+    id,
+    type: "clock",
+    defaultSlot: "trigger",
+    audioContext: ctx.audioContext,
+    nodes: { osc },
+    connections: { trigger: [] },
+    connect(params) {
+      connectNodes({
+        ...params,
+        source: this,
+      });
+    },
+    disconnect(params) {
+      disconnectNodes({
+        ...params,
+        source: this,
+      });
+    },
+    update(params) {
+      console.log(params);
+      const { bpm = 60.0 } = params as ClockGraphNodeParameters;
+      const freq = bpm / 60.0;
+
+      const osc = this.nodes.osc;
+      osc.frequency.value = freq;
+
+      this.reset();
+      this.start();
+    },
+    destroy() {
+      const osc = this.nodes.osc;
+
+      osc.stop();
+      osc.disconnect();
+    },
+    start() {
+      const osc = this.nodes.osc;
+      const ctx = this.audioContext;
+
+      osc.start();
+      osc.stop(ctx.currentTime + 1.0 / osc.frequency.value);
+      osc.onended = () => {
+        console.log(
+          `clock ${node.id} triggered at ${node.audioContext.currentTime}`,
+        );
+
+        this.reset();
+        this.start();
+      };
+    },
+    reset() {
+      const oldOsc = this.nodes.osc;
+      oldOsc.onended = null;
+      oldOsc.stop();
+
+      const newOsc = this.audioContext.createOscillator();
+      newOsc.frequency.value = this.nodes.osc.frequency.value;
+      newOsc.type = "sawtooth";
+
+      this.nodes.osc = newOsc;
+    },
+  };
+
+  node.start();
+
+  return node;
+};

--- a/lib/audio-graph/src/nodes/dac.ts
+++ b/lib/audio-graph/src/nodes/dac.ts
@@ -10,6 +10,8 @@ export interface DacGraphNode extends AudioGraphNode {
   nodes: {
     dac: AudioDestinationNode;
   };
+  inputs: {};
+  outputs: {};
 }
 
 export const createDac = (
@@ -30,6 +32,8 @@ export const createDac = (
     audioContext: ctx.audioContext,
     nodes: { dac },
     connections: {},
+    inputs: {},
+    outputs: {},
     connect() {
       console.warn("A DAC node does not support connections.");
     },

--- a/lib/audio-graph/src/nodes/factory.ts
+++ b/lib/audio-graph/src/nodes/factory.ts
@@ -4,6 +4,7 @@ import {
   AudioGraphNodeParameters,
   AudioGraphNodeType,
 } from "./base";
+import { createClock } from "./clock";
 import { createDac } from "./dac";
 import { createGain } from "./gain";
 import { createOscillator } from "./oscillator";
@@ -17,6 +18,7 @@ const factories: Record<
   AudioGraphNodeType,
   (params: AudioGraphFactoryParameters) => AudioGraphNode
 > = {
+  clock: createClock,
   dac: createDac,
   gain: createGain,
   osc: createOscillator,

--- a/lib/audio-graph/src/nodes/gain.ts
+++ b/lib/audio-graph/src/nodes/gain.ts
@@ -14,6 +14,20 @@ export interface GainGraphNode extends AudioGraphNode {
   connections: {
     gain: string[];
   };
+  inputs: {
+    gain: {
+      key: "gain";
+      name: "Gain";
+      rate: "audio";
+    };
+  };
+  outputs: {
+    gain: {
+      key: "gain";
+      name: "Gain";
+      rate: "audio";
+    };
+  };
 }
 
 export const createGain = (
@@ -37,6 +51,20 @@ export const createGain = (
     nodes: { gain },
     connections: {
       gain: [],
+    },
+    inputs: {
+      gain: {
+        key: "gain",
+        name: "Gain",
+        rate: "audio",
+      },
+    },
+    outputs: {
+      gain: {
+        key: "gain",
+        name: "Gain",
+        rate: "audio",
+      },
     },
     connect(params) {
       connectNodes({

--- a/lib/audio-graph/src/nodes/oscillator.ts
+++ b/lib/audio-graph/src/nodes/oscillator.ts
@@ -16,6 +16,25 @@ export interface OscillatorGraphNode extends AudioGraphNode {
   connections: {
     osc: string[];
   };
+  inputs: {
+    frequency: {
+      key: "frequency";
+      name: "Frequency";
+      rate: "audio";
+    };
+    waveform: {
+      key: "frequency";
+      name: "Frequency";
+      rate: "constant";
+    };
+  };
+  outputs: {
+    audio: {
+      key: "audio";
+      name: "Audio";
+      rate: "audio";
+    };
+  };
 }
 
 export const createOscillator = (
@@ -27,10 +46,13 @@ export const createOscillator = (
     throw Error("AudioContext is required to create nodes.");
   }
 
+  const defaultFreq = 440.0;
+  const defaultWaveform = "sine";
+
   const osc = ctx.audioContext.createOscillator();
   const { frequency, waveform } = params as OscillatorGraphNodeParameters;
-  osc.frequency.value = frequency ?? 440.0;
-  osc.type = waveform ?? "sine";
+  osc.frequency.value = frequency ?? defaultFreq;
+  osc.type = waveform ?? defaultWaveform;
   osc.start();
 
   const node: OscillatorGraphNode = {
@@ -39,6 +61,25 @@ export const createOscillator = (
     defaultSlot: "osc",
     nodes: { osc, freq: osc.frequency },
     connections: { osc: [] },
+    inputs: {
+      frequency: {
+        key: "frequency",
+        name: "Frequency",
+        rate: "audio",
+      },
+      waveform: {
+        key: "frequency",
+        name: "Frequency",
+        rate: "constant",
+      },
+    },
+    outputs: {
+      audio: {
+        key: "audio",
+        name: "Audio",
+        rate: "audio",
+      },
+    },
     connect(params) {
       connectNodes({
         ...params,

--- a/web/src/app/components/MusicCanvas.tsx
+++ b/web/src/app/components/MusicCanvas.tsx
@@ -12,7 +12,7 @@ import "reactflow/dist/style.css";
 import { WebAudioContext } from "../lib";
 import { AppStore, useStore } from "../store";
 import { useShallow } from "zustand/react/shallow";
-import { Oscillator, Gain, Output } from "./";
+import { Oscillator, Gain, Output, Clock } from "./";
 import { useContext, useMemo } from "react";
 
 const selector = (store: AppStore) => ({
@@ -20,6 +20,7 @@ const selector = (store: AppStore) => ({
 });
 
 const nodeTypes = {
+  clock: Clock,
   gain: Gain,
   osc: Oscillator,
   dac: Output,
@@ -73,6 +74,12 @@ export const MusicCanvas = () => {
           onClick={() => addNode(ctx, "gain")}
         >
           Add Gain
+        </button>
+        <button
+          className="px-2 py-1 rounded bg-cardbg shadow-md"
+          onClick={() => addNode(ctx, "clock")}
+        >
+          Add Clock
         </button>
       </Panel>
       <Background variant={BackgroundVariant.Dots} />

--- a/web/src/app/components/index.ts
+++ b/web/src/app/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./MusicCanvas";
+export * from "./nodes/Clock";
 export * from "./nodes/Gain";
 export * from "./nodes/Oscillator";
 export * from "./nodes/Output";

--- a/web/src/app/components/nodes/Clock.tsx
+++ b/web/src/app/components/nodes/Clock.tsx
@@ -1,0 +1,49 @@
+import { WebAudio } from "@audio-graph";
+import { AppStore, useStore } from "../../store";
+import { ChangeEvent, useContext } from "react";
+import { WebAudioContext } from "../../lib";
+import { useShallow } from "zustand/react/shallow";
+import { NodeCard } from "./NodeCard";
+import { Position } from "reactflow";
+
+export interface ClockData {
+  bpm: number;
+}
+
+const selector = (ctx: WebAudio, id: string) => (store: AppStore) => ({
+  setBpm: (e: ChangeEvent<HTMLInputElement>) =>
+    store.updateNode(ctx, id, { bpm: +e.target.value }),
+});
+
+export const Clock = ({ id, data }: { id: string; data: ClockData }) => {
+  const ctx = useContext(WebAudioContext);
+  const { setBpm } = useStore(useShallow(selector(ctx, id)));
+
+  return (
+    <NodeCard
+      title="Clock"
+      handles={[
+        {
+          id: "output#trigger",
+          position: Position.Bottom,
+          type: "source",
+        },
+      ]}
+    >
+      <label className="flex flex-col px-2 pt-1 pb-4">
+        <span className="text-xs font-bold my-2">Bpm</span>
+        <div className="flex justify-end bg-inputbg py-2 pe-2 rounded-md">
+          <input
+            className="nodrag bg-transparent text-right grow"
+            type="number"
+            min="0"
+            max="240"
+            step="0.1"
+            value={data.bpm}
+            onChange={setBpm}
+          />
+        </div>
+      </label>
+    </NodeCard>
+  );
+};

--- a/web/src/app/lib/web-audio/provider.tsx
+++ b/web/src/app/lib/web-audio/provider.tsx
@@ -4,6 +4,7 @@ import { createContext, ReactNode, useEffect, useState } from "react";
 import {
   AudioGraphNode,
   WebAudio,
+  createControlEventCoordinator,
   createNode,
   updateNode,
   deleteNode,
@@ -11,6 +12,7 @@ import {
   connect,
   disconnect,
   isRunning,
+  ControlEventCoordinator,
 } from "@audio-graph";
 
 export const WebAudioContext = createContext<WebAudio>({
@@ -26,6 +28,8 @@ export const WebAudioContext = createContext<WebAudio>({
 
 export const WebAudioProvider = ({ children }: { children: ReactNode }) => {
   const [audioContext, setAudioContext] = useState<AudioContext>();
+  const [eventCoordinator, setEventCoordinator] =
+    useState<ControlEventCoordinator>();
   const [nodes] = useState<{ [key: string]: AudioGraphNode }>({});
   useEffect(() => {
     if (audioContext) {
@@ -37,12 +41,18 @@ export const WebAudioProvider = ({ children }: { children: ReactNode }) => {
     ctx.suspend();
 
     setAudioContext(ctx);
+
+    console.log("Creating event coordinator");
+    const coord = createControlEventCoordinator();
+
+    setEventCoordinator(coord);
   }, [audioContext]);
 
   return (
     <WebAudioContext.Provider
       value={{
         audioContext,
+        eventCoordinator,
         nodes,
         createNode,
         updateNode,

--- a/web/src/app/store.ts
+++ b/web/src/app/store.ts
@@ -29,6 +29,14 @@ export interface AppStore {
   toggleAudio: (ctx: WebAudio) => void;
 }
 
+const defaultParameters: Record<AudioGraphNodeType, AudioGraphNodeParameters> =
+  {
+    clock: { bpm: 60.0 },
+    dac: {},
+    gain: { gain: 1.0 },
+    osc: { frequency: 440, waveform: "sine" },
+  };
+
 export const useStore = create(
   (set, get: () => AppStore): AppStore => ({
     isAudioRunning: false,
@@ -54,26 +62,7 @@ export const useStore = create(
     addNode(ctx: WebAudio, type: AudioGraphNodeType) {
       const id = nanoid();
       const position = { x: 0, y: 0 };
-      let data: AudioGraphNodeParameters;
-
-      switch (type) {
-        case "osc": {
-          data = { frequency: 440, waveform: "sine" };
-          break;
-        }
-
-        case "gain": {
-          data = { gain: 1.0 };
-          break;
-        }
-
-        case "dac":
-          data = {};
-          break;
-
-        default:
-          return;
-      }
+      const data = defaultParameters[type];
 
       ctx.createNode({ ctx, id, type, ...data });
       set({ nodes: [...get().nodes, { id, type, data, position }] });


### PR DESCRIPTION
# Summary

- Creates an event coordinator for mediating control-rate messages
- Adds a clock node that dispatches control-rate triggers
- Fleshes out node slot definitions, allowing nodes to define what rate (audio or control) a parameter is

# TODO

Currently, the clock node is the only control-rate node. It can't trigger anything other than its own blinking light.